### PR TITLE
CI: add circle-ci integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
 
-      - sudo apt-get install -y rsync
+      - run: sudo apt-get install -y rsync
 
       # Already in npm build script :)
       # - run: git submodule update --init --recursive --remote

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+# Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8.9
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Already in npm build script :)
+      # - run:
+      #     name: Checking out newest submodules
+      #     command: git submodule update --init --recursive --remote
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - run: npm run-script build
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # deploy
+      - deploy:
+          name: "Publish Website"
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "circle-ci" ]; then
+              ls -lR dist
+            fi
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
+
+      - add_ssh_keys:
+          fingerprints:
+            - "b6:fa:4a:76:8a:64:26:7b:1c:47:67:7d:5c:61:a0:ac"
+
       # deploy
       - deploy:
           name: "Publish Website"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,17 +35,13 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-
-      - add_ssh_keys:
-          fingerprints:
-            - "64:19:1a:f0:47:0b:23:e3:57:d8:d7:a2:4b:31:05:a3"
-
       # deploy
       - deploy:
           name: "Publish Website"
           command: |
             if [ "${CIRCLE_BRANCH}" == "circle-ci" ]; then
-              rsync -avz dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}"
+              ssh-keyscan "${DEPLOY_HOST}" >> ~/.ssh/known_hosts ;
+              rsync -avz dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}" ;
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "b6:fa:4a:76:8a:64:26:7b:1c:47:67:7d:5c:61:a0:ac"
+            - "64:19:1a:f0:47:0b:23:e3:57:d8:d7:a2:4b:31:05:a3"
 
       # deploy
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,7 @@ jobs:
       - checkout
 
       # Already in npm build script :)
-      # - run:
-      #     name: Checking out newest submodules
-      #     command: git submodule update --init --recursive --remote
+      # - run: git submodule update --init --recursive --remote
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - checkout
 
+      - sudo apt-get install -y rsync
+
       # Already in npm build script :)
       # - run: git submodule update --init --recursive --remote
 
@@ -38,7 +40,7 @@ jobs:
           name: "Publish Website"
           command: |
             if [ "${CIRCLE_BRANCH}" == "circle-ci" ]; then
-              ls -lR dist
+              rsync -avz dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}"
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
       - deploy:
           name: "Publish Website"
           command: |
-            if [ "${CIRCLE_BRANCH}" == "circle-ci" ]; then
-              ssh-keyscan "${DEPLOY_HOST}" >> ~/.ssh/known_hosts ;
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ssh-keyscan "${DEPLOY_HOST}" >> ~/.ssh/known_hosts 2>/dev/null;
               rsync -avz dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}" ;
             fi
 


### PR DESCRIPTION
To enable auto deployment:

- Enable this project in https://circleci.com
- Under project settings
    - `SSH Permissions` tab: Add host private key, leaving hostname empty is ok
    -  `Environment Variables` tab:
        - `DEPLOY_HOST` variable, ip address is ok
        - `DEPLOY_USER`
        - `DEPLOY_PATH`: /home/xxxx/path/to/website/root


+Question:
will this repo always update its submodules to newest? or update manually(via script) to make website content version traceable. Each push master triggers deployment.
